### PR TITLE
Fix recent redis breakage

### DIFF
--- a/Kitura-Session-Redis/osx/before_tests.sh
+++ b/Kitura-Session-Redis/osx/before_tests.sh
@@ -20,7 +20,7 @@
 set -e
 
 # Install redis
-brew install redis || brew outdated redis || brew upgrade redis
+brew install redis --build-from-source || brew outdated redis || brew upgrade redis
 
 # Set environment variable that points to conf file
 export REDIS_CONF_FILE=/usr/local/etc/redis.conf

--- a/Kitura-redis/osx/before_tests.sh
+++ b/Kitura-redis/osx/before_tests.sh
@@ -20,7 +20,7 @@
 set -e
 
 # Install redis
-brew install redis || brew outdated redis || brew upgrade redis
+brew install redis --build-from-source || brew outdated redis || brew upgrade redis
 
 # Set environment variable that points to conf file
 export REDIS_CONF_FILE=/usr/local/etc/redis.conf


### PR DESCRIPTION
A recent brew or redis update is causing the script to fail with this message: Fatal error, can't open config file '/usr/local/etc/redis.conf'

Link to brew issue: https://github.com/Homebrew/homebrew-core/issues/11175
Solution I chose for this PR: https://github.com/Homebrew/homebrew-core/issues/11134#issuecomment-287542363

Successful build with this change: https://travis-ci.org/IBM-Swift/Kitura-redis/jobs/213541738