### PR TITLE
fix: Redis-server in Ubuntu 18.04 Docker image does not start

### DIFF
--- a/Kitura-redis/common/before_tests.sh
+++ b/Kitura-redis/common/before_tests.sh
@@ -30,6 +30,8 @@ echo ">> redis password: $password"
 
 # Update redis password
 sudo perl -pi -e "s/# requirepass foobared/requirepass ${password}/g" $REDIS_CONF_FILE
+# Strip ipv6 syntax from bind address (fails under Docker)
+sudo perl -pi -e "s/bind 127.0.0.1.*/bind 127.0.0.1/g" $REDIS_CONF_FILE
 
 echo ">> Contents of ${REDIS_CONF_FILE} next:"
 cat $REDIS_CONF_FILE


### PR DESCRIPTION
The `redis-server` package on Ubuntu 18.04 seems to define the server port bind as `bind 127.0.0.1 ::1` in order to bind to localhost on both ipv4 and ipv6 protocols.  However, Docker does not (by default) provide an ipv6 stack, so the bind fails and the server does not start.

This strips the `::1` from the default bind so that Redis starts under Docker.

Example job: https://travis-ci.org/IBM-Swift/Kitura-redis/builds/507957993